### PR TITLE
Remove TODOs and unneeded headers (Part of WAL-4567)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,20 +202,13 @@ const server = Bun.serve({
 						senderPublicKey,
 					);
 
-					const res = Response.json({
+					return Response.json({
 						...encryptedResponse,
 						shares: {
 							auth: unencryptedResponse.shares.auth,
 						},
 						deviceKeyShareHash,
 					});
-
-					res.headers.set("Access-Control-Allow-Origin", "*"); // TODO: restrict to xm
-					res.headers.set(
-						"Access-Control-Allow-Methods",
-						"GET, POST, PUT, DELETE, OPTIONS",
-					);
-					return res;
 				} catch (error) {
 					return handleError(error, "POST /requests/:requestId/auth");
 				}
@@ -225,12 +218,9 @@ const server = Bun.serve({
 			async GET(req) {
 				const pubKeyBuffer = await services.encryptionService.getPublicKey();
 				const pubKeyBase64 = Buffer.from(pubKeyBuffer).toString("base64");
-				const res = Response.json({
+				return Response.json({
 					publicKey: pubKeyBase64,
 				});
-				res.headers.set("Access-Control-Allow-Origin", "*"); // TODO: restrict to iframe
-				res.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
-				return res;
 			},
 		},
 


### PR DESCRIPTION
## Descriptions

This PR removes unnecessary headers we we're adding, and drops some associated TODOs that are covered in https://github.com/Paella-Labs/crossbit-main/pull/18942.

Access to the TEE is guarded by a secret held by Crossmint's main service, afaik there's no need to restrict headers, or worry about requests coming from the browser.

## Testing

Using my local copy of the quickstart within the SDK workspace, I tested the entire flow e2e.