### PR TITLE
Attestation Endpoint(s) (part of WAL-4545)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,10 +24,6 @@ export const ENVSchema = z.object({
 		.string()
 		.default("true")
 		.transform((val) => val === "true"),
-	DEVELOPMENT_MODE: z
-		.string()
-		.default("false")
-		.transform((val) => val === "true"),
 });
 
 export type EnvConfig = z.infer<typeof ENVSchema>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,8 +22,11 @@ export const ENVSchema = z.object({
 		.min(1, { message: "DATADOG_API_KEY is required" }),
 	DATADOG_METRICS_ENABLED: z
 		.string()
-		.optional()
 		.default("true")
+		.transform((val) => val === "true"),
+	DEVELOPMENT_MODE: z
+		.string()
+		.default("false")
 		.transform((val) => val === "true"),
 });
 

--- a/src/features/attestation/attestation.controller.ts
+++ b/src/features/attestation/attestation.controller.ts
@@ -1,11 +1,15 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../../types";
-import { attestationHandler } from "./attestation.handler";
+import {
+	getAttestationHandler,
+	getTEEPublicKeyHandler,
+} from "./attestation.handler";
 import { authMiddleware } from "middleware/auth.middleware";
 
 const attestation = new Hono<AppEnv>();
 
-attestation.get("/", attestationHandler);
+attestation.get("/", getAttestationHandler);
+attestation.get("/public-key", getTEEPublicKeyHandler); // primarily for local development
 attestation.use("*", authMiddleware());
 
 export default attestation;

--- a/src/features/attestation/attestation.controller.ts
+++ b/src/features/attestation/attestation.controller.ts
@@ -1,16 +1,11 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../../types";
-import {
-	getTDXQuoteHandler,
-	getTEEPublicKeyHandler,
-} from "./attestation.handler";
+import { attestationHandler } from "./attestation.handler";
 import { authMiddleware } from "middleware/auth.middleware";
 
 const attestation = new Hono<AppEnv>();
 
-attestation.get("/", getTEEPublicKeyHandler); // Backwards compatibility TODO delete
-attestation.get("/public-key", getTEEPublicKeyHandler);
-attestation.get("/tdx-quote", getTDXQuoteHandler);
+attestation.get("/", attestationHandler);
 attestation.use("*", authMiddleware());
 
 export default attestation;

--- a/src/features/attestation/attestation.handler.ts
+++ b/src/features/attestation/attestation.handler.ts
@@ -1,22 +1,22 @@
-import { env } from "config";
 import type { AppContext } from "../../types";
 import { TappdClient } from "@phala/dstack-sdk";
 
-export const attestationHandler = async (c: AppContext) => {
+export const getAttestationHandler = async (c: AppContext) => {
 	const services = c.get("services");
 	const pubKeyBuffer = await services.encryptionService.getPublicKey();
+	const result = await new TappdClient().tdxQuote(new Uint8Array(pubKeyBuffer));
 
 	return c.json({
-		quote: await getQuote(pubKeyBuffer),
+		quote: result.quote,
 		publicKey: Buffer.from(pubKeyBuffer).toString("base64"),
 	});
 };
 
-async function getQuote(publicKey: ArrayBuffer): Promise<string> {
-	if (env.DEVELOPMENT_MODE) {
-		return Buffer.from("mock-quote").toHex();
-	}
+export const getTEEPublicKeyHandler = async (c: AppContext) => {
+	const services = c.get("services");
+	const pubKeyBuffer = await services.encryptionService.getPublicKey();
 
-	const result = await new TappdClient().tdxQuote(new Uint8Array(publicKey));
-	return result.quote;
-}
+	return c.json({
+		publicKey: Buffer.from(pubKeyBuffer).toString("base64"),
+	});
+};


### PR DESCRIPTION
## Description

This PR:
- Removes `/attestation/tdx-quote` endpoint, moving that functionality to `/attestation`.
- Keeps `/attestation/public-key` for use during local development
- Adds the TEE public key to the Attestation