### PR TITLE
Include event logs and replays (part of WAL-4654)

### DIFF
--- a/src/features/attestation/attestation.handler.ts
+++ b/src/features/attestation/attestation.handler.ts
@@ -7,7 +7,7 @@ export const getAttestationHandler = async (c: AppContext) => {
 	const result = await new TappdClient().tdxQuote(new Uint8Array(pubKeyBuffer));
 
 	return c.json({
-		quote: result.quote,
+		...result,
 		publicKey: Buffer.from(pubKeyBuffer).toString("base64"),
 	});
 };


### PR DESCRIPTION
## description

[From Dtack gh](https://github.com/Dstack-TEE/dstack/blob/master/attestation.md)

> RTMR3 differs as it contains runtime information like compose hash and instance id. Verify this by replaying the event log - if the calculated RTMR3 matches the quote's RTMR3, the event log information is valid. Then verify the compose hash, key provider, and other event log details match expectations.

For compose hash based application integrity checks, this PR adds the event log to the `GET v1/attestation` response.